### PR TITLE
docs: clarify public scores userId filter description

### DIFF
--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -21,7 +21,7 @@ service:
             docs: Limit of items per page. If you encounter api issues due to too large page sizes, try to reduce the limit.
           userId:
             type: optional<string>
-            docs: Retrieve only scores with this userId associated to the trace.
+            docs: Retrieve only scores where this userId matches the related trace or session.
           name:
             type: optional<string>
             docs: Retrieve only scores with this name.

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3990,7 +3990,7 @@ paths:
             nullable: true
         - name: userId
           in: query
-          description: Retrieve only scores with this userId associated to the trace.
+          description: Retrieve only scores where this userId matches the related trace or session.
           required: false
           schema:
             type: string

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -2939,7 +2939,7 @@
                 {
                   "key": "userId",
                   "value": "",
-                  "description": "Retrieve only scores with this userId associated to the trace."
+                  "description": "Retrieve only scores where this userId matches the related trace or session."
                 },
                 {
                   "key": "name",


### PR DESCRIPTION
## Summary
- clarify the public scores userId filter documentation to cover both trace- and session-derived users

## Testing
- pnpm exec prettier --check fern/apis/server/definition/score-v2.yml

------
https://chatgpt.com/codex/tasks/task_e_68e91ed1eb44832f80eac04af2f9472b